### PR TITLE
Make explanation of srun consistent with code

### DIFF
--- a/docs/index.Rmd
+++ b/docs/index.Rmd
@@ -419,7 +419,7 @@ srun --pty --time=0:10:00 -c 1 --mem 1024 bash
 ```
 
 + `--pty` (gives us a prompt)
-+ `--time` (we're asking for 20 minutes of time on the reserved node)
++ `--time` (we're asking for 10 minutes of time on the reserved node)
 + `-c` (request number of CPUs, notice it's a `-` and not a `--`)
 + `--mem` (request memory in megabytes, we're asking for 1 Gig of memory)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1788,7 +1788,7 @@ srun /opt/installed/samtools-1.6/bin/samtools index $arrayfile</code></pre>
 <pre><code>srun --pty --time=0:10:00 -c 1 --mem 1024 bash</code></pre>
 <ul>
 <li><code>--pty</code> (gives us a prompt)</li>
-<li><code>--time</code> (we’re asking for 20 minutes of time on the reserved node)</li>
+<li><code>--time</code> (we’re asking for 10 minutes of time on the reserved node)</li>
 <li><code>-c</code> (request number of CPUs, notice it’s a <code>-</code> and not a <code>--</code>)</li>
 <li><code>--mem</code> (request memory in megabytes, we’re asking for 1 Gig of memory)</li>
 </ul>


### PR DESCRIPTION
The SLURM code shows a requested time of 10, while the explanation
describes value as 20. This commit changes the description to match the
mentioned 10 minutes requested in the SLURM code block.