### PR TITLE
Update interactive job to use light partition

### DIFF
--- a/docs/index.Rmd
+++ b/docs/index.Rmd
@@ -162,7 +162,7 @@ Before we even do something on exacloud, we're going to look at how exacloud is 
 ```
 scontrol show partition
 ```
-That's a lot of information! Let's just focus on the partition names. There are five main partitions of compute nodes that you should have access to: `exacloud`, `highio`, `light`, `long_jobs`, and `very_long_jobs`. 
+That's a lot of information! Let's just focus on the partition names. There are five main partitions of compute nodes that you should have access to: `exacloud`, `highio`, `light`, `long_jobs`, and `very_long_jobs`.
 
 If you want to see the other partitions (including those you don't currently have access to), you can use the `-a` flag. Currently, there are a couple of partitions not accessible to everyone: `gpu`, and `mpi`. If you need to use these, you can request access via ACC.
 
@@ -415,13 +415,14 @@ hostname
 1. Let's request an interactive session. The way we do this is by using `srun`, with a few options (see below). What about `bash`? We're opening a `bash` shell on our requested node, which means we can run any commands there.
 
 ```
-srun --pty --time=0:10:00 -c 1 --mem 1024 bash
+srun --pty --time=0:10:00 -c 1 --mem 1024 -p light bash
 ```
 
 + `--pty` (gives us a prompt)
 + `--time` (we're asking for 10 minutes of time on the reserved node)
 + `-c` (request number of CPUs, notice it's a `-` and not a `--`)
 + `--mem` (request memory in megabytes, we're asking for 1 Gig of memory)
++ `-p` (specify which partition to use, namely the `light` partition for interactive use)
 
 2. Let's confirm that we're on a different node. Type `hostname` and make sure that you're not on `exahead1`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1785,12 +1785,13 @@ srun /opt/installed/samtools-1.6/bin/samtools index $arrayfile</code></pre>
 <ol style="list-style-type: decimal">
 <li>Let’s request an interactive session. The way we do this is by using <code>srun</code>, with a few options (see below). What about <code>bash</code>? We’re opening a <code>bash</code> shell on our requested node, which means we can run any commands there.</li>
 </ol>
-<pre><code>srun --pty --time=0:10:00 -c 1 --mem 1024 bash</code></pre>
+<pre><code>srun --pty --time=0:10:00 -c 1 --mem 1024 -p light bash</code></pre>
 <ul>
 <li><code>--pty</code> (gives us a prompt)</li>
 <li><code>--time</code> (we’re asking for 10 minutes of time on the reserved node)</li>
 <li><code>-c</code> (request number of CPUs, notice it’s a <code>-</code> and not a <code>--</code>)</li>
 <li><code>--mem</code> (request memory in megabytes, we’re asking for 1 Gig of memory)</li>
+<li><code>-p</code> (specify which partition to use, namely the <code>light</code> partition for interactive use)</li>
 </ul>
 <ol start="2" style="list-style-type: decimal">
 <li><p>Let’s confirm that we’re on a different node. Type <code>hostname</code> and make sure that you’re not on <code>exahead1</code>.</p></li>


### PR DESCRIPTION
Official Exacloud documentation suggests to use the light partition when
doing interactive jobs.

See https://accdoc.ohsu.edu/exacloud/guide/job-scheduler/#interactive-sessions